### PR TITLE
updates the @moki-{client,server} module ver

### DIFF
--- a/Moki/client/package-generic.json
+++ b/Moki/client/package-generic.json
@@ -10,11 +10,11 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "homepage": "." ,
+  "homepage": ".",
   "dependencies": {
-    "@moki-client/es-response-parser": "git+https://git@github.com/intuitivelabs/es-response-parser.git#master",
-    "@moki-client/gui": "git+https://git@github.com/intuitivelabs/moki-gui.git#master",
-    "@moki-client/react-bootstrap-table-next": "git+https://git@github.com/intuitivelabs/react-bootstrap-table2-1.git#master",
+    "@moki-client/es-response-parser": "git+https://git@github.com/intuitivelabs/es-response-parser.git#v0.0.1",
+    "@moki-client/gui": "git+https://git@github.com/intuitivelabs/moki-gui.git#v0.0.1",
+    "@moki-client/react-bootstrap-table-next": "git+https://git@github.com/intuitivelabs/react-bootstrap-table2-1.git#v0.0.1",
     "bootstrap": "^4.6.0",
     "classnames": "^2.2.6",
     "d3": "^5.7.0",

--- a/Moki/server/package.json
+++ b/Moki/server/package.json
@@ -2,7 +2,7 @@
   "name": "moki-express",
   "version": "1.1.0",
   "description": "Moki express server",
-  "author":  "Frafos, Intuitive Labs",
+  "author": "Frafos, Intuitive Labs",
   "license": "Apache-2.0",
   "licenses": [
     {
@@ -10,7 +10,7 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "homepage":  "https://www.frafos.com/  https://www.intuitivelabs.com/",
+  "homepage": "https://www.frafos.com/  https://www.intuitivelabs.com/",
   "scripts": {
     "start": "node src/app.js",
     "dev": "nodemon",
@@ -25,7 +25,7 @@
     "ncu": "ncu"
   },
   "dependencies": {
-    "@moki-server/server": "git+https://git@github.com/intuitivelabs/moki-server.git#master",
+    "@moki-server/server": "git+https://git@github.com/intuitivelabs/moki-server.git#v0.0.1",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
- git tags are used in package.json:
    "@moki-client/es-response-parser": "git+https://git@github.com/intuitivelabs/es-response-parser.git#v0.0.1",
    "@moki-client/gui": "git+https://git@github.com/intuitivelabs/moki-gui.git#v0.0.1",
    "@moki-client/react-bootstrap-table-next": "git+https://git@github.com/intuitivelabs/react-bootstrap-table2-1.git#v0.0.1",