### PR TITLE
call-start in front of call-end order

### DIFF
--- a/Moki/server/js/template_queries/timerange_query.js
+++ b/Moki/server/js/template_queries/timerange_query.js
@@ -8,8 +8,9 @@ var getTemplate = function (queries, supress, source, size = 500) {
                     "order": "desc",
                     "unmapped_type": "boolean"
                 }
-            }
-            ],
+            },
+            { "attrs.type": { "order": "asc" } }
+        ],
         "query": {
             "bool": {
                 "must": queries,
@@ -23,7 +24,7 @@ var getTemplate = function (queries, supress, source, size = 500) {
 
     };
 
-    if(source !== "*"){
+    if (source !== "*") {
         template._source = source;
     }
     return template;


### PR DESCRIPTION
if timestamp of events is same, order by name so call-start is ahead of call-end for short calls